### PR TITLE
fix: QName constructor calls

### DIFF
--- a/src/main/java/org/swordapp/server/AtomStatement.java
+++ b/src/main/java/org/swordapp/server/AtomStatement.java
@@ -87,18 +87,18 @@ public class AtomStatement extends Statement {
             if (deposit.getMediaType() != null) {
                 entry.setContent(new IRI(deposit.getUri()), deposit.getMediaType());
             }
-            entry.addCategory(UriRegistry.SWORD_TERMS_NAMESPACE, UriRegistry.SWORD_ORIGINAL_DEPOSIT, "Original Deposit");
+            entry.addCategory(UriRegistry.SWORD_TERMS_NAMESPACE, UriRegistry.SWORD_ORIGINAL_DEPOSIT_URI, "Original Deposit");
             if (deposit.getDepositedOn() != null) {
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-                entry.addSimpleExtension(new QName(UriRegistry.SWORD_DEPOSITED_ON), sdf.format(deposit.getDepositedOn()));
+                entry.addSimpleExtension(UriRegistry.SWORD_DEPOSITED_ON, sdf.format(deposit.getDepositedOn()));
             }
 
             if (deposit.getDepositedOnBehalfOf() != null) {
-                entry.addSimpleExtension(new QName(UriRegistry.SWORD_DEPOSITED_ON_BEHALF_OF), deposit.getDepositedOnBehalfOf());
+                entry.addSimpleExtension(UriRegistry.SWORD_DEPOSITED_ON_BEHALF_OF, deposit.getDepositedOnBehalfOf());
             }
 
             if (deposit.getDepositedBy() != null) {
-                entry.addSimpleExtension(new QName(UriRegistry.SWORD_DEPOSITED_BY), deposit.getDepositedBy());
+                entry.addSimpleExtension(UriRegistry.SWORD_DEPOSITED_BY, deposit.getDepositedBy());
             }
 
             if (deposit.getPackaging() != null) {
@@ -110,7 +110,7 @@ public class AtomStatement extends Statement {
     
         // now at the state as a categories
         for (Map.Entry<String, String> state : this.states.entrySet()) {
-            Category cat = feed.addCategory(UriRegistry.SWORD_STATE, state.getKey(), "State");
+            Category cat = feed.addCategory(UriRegistry.SWORD_STATE_URI, state.getKey(), "State");
             if (state.getValue() != null) {
                 cat.setText(state.getValue());
             }

--- a/src/main/java/org/swordapp/server/OREStatement.java
+++ b/src/main/java/org/swordapp/server/OREStatement.java
@@ -54,16 +54,16 @@ public class OREStatement extends Statement {
             Resource deposit = model.createResource(od.getUri());
             deposit.addProperty(RDF.type, model.createResource(UriRegistry.ORE_NAMESPACE + "AggregatedResource"));
             if (od.getDepositedBy() != null) {
-                deposit.addLiteral(model.createProperty(UriRegistry.SWORD_DEPOSITED_BY), od.getDepositedBy());
+                deposit.addLiteral(model.createProperty(UriRegistry.SWORD_DEPOSITED_BY_URI), od.getDepositedBy());
             }
 
             if (od.getDepositedOnBehalfOf() != null) {
-                deposit.addLiteral(model.createProperty(UriRegistry.SWORD_DEPOSITED_ON_BEHALF_OF), od.getDepositedOnBehalfOf());
+                deposit.addLiteral(model.createProperty(UriRegistry.SWORD_DEPOSITED_ON_BEHALF_OF_URI), od.getDepositedOnBehalfOf());
             }
 
             if (od.getDepositedOn() != null) {
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-                deposit.addLiteral(model.createProperty(UriRegistry.SWORD_DEPOSITED_ON), sdf.format(od.getDepositedOn()));
+                deposit.addLiteral(model.createProperty(UriRegistry.SWORD_DEPOSITED_ON_URI), sdf.format(od.getDepositedOn()));
             }
 
             for (String packaging : od.getPackaging()) {
@@ -71,16 +71,16 @@ public class OREStatement extends Statement {
             }
 
             agg.addProperty(model.createProperty(UriRegistry.ORE_NAMESPACE + "aggregates"), deposit);
-            agg.addProperty(model.createProperty(UriRegistry.SWORD_ORIGINAL_DEPOSIT), deposit);
+            agg.addProperty(model.createProperty(UriRegistry.SWORD_ORIGINAL_DEPOSIT_URI), deposit);
         }
 
         // now add the state information
         for (Map.Entry<String, String> state : this.states.entrySet()) {
             Resource s = model.createResource(state.getKey());
             if (state.getValue() != null) {
-                s.addProperty(model.createProperty(UriRegistry.SWORD_STATE_DESCRIPTION), state.getValue());
+                s.addProperty(model.createProperty(UriRegistry.SWORD_STATE_DESCRIPTION_URI), state.getValue());
             }
-            agg.addProperty(model.createProperty(UriRegistry.SWORD_STATE), s);
+            agg.addProperty(model.createProperty(UriRegistry.SWORD_STATE_URI), s);
         }
 
         // write the model directly to the output

--- a/src/main/java/org/swordapp/server/UriRegistry.java
+++ b/src/main/java/org/swordapp/server/UriRegistry.java
@@ -34,12 +34,20 @@ public final class UriRegistry {
     public static final QName DC_ABSTRACT = new QName(DC_NAMESPACE, "abstract");
 
     // URIs for the statement
-    public static final String SWORD_DEPOSITED_BY = SWORD_TERMS_NAMESPACE + "depositedBy";
-    public static final String SWORD_DEPOSITED_ON_BEHALF_OF = SWORD_TERMS_NAMESPACE + "depositedOnBehalfOf";
-    public static final String SWORD_DEPOSITED_ON = SWORD_TERMS_NAMESPACE + "depositedOn";
-    public static final String SWORD_ORIGINAL_DEPOSIT = SWORD_TERMS_NAMESPACE + "originalDeposit";
-    public static final String SWORD_STATE_DESCRIPTION = SWORD_TERMS_NAMESPACE + "stateDescription";
-    public static final String SWORD_STATE = SWORD_TERMS_NAMESPACE + "state";
+    public static final String SWORD_DEPOSITED_BY_URI = SWORD_TERMS_NAMESPACE + "depositedBy";
+    public static final String SWORD_DEPOSITED_ON_BEHALF_OF_URI = SWORD_TERMS_NAMESPACE + "depositedOnBehalfOf";
+    public static final String SWORD_DEPOSITED_ON_URI = SWORD_TERMS_NAMESPACE + "depositedOn";
+    public static final String SWORD_ORIGINAL_DEPOSIT_URI = SWORD_TERMS_NAMESPACE + "originalDeposit";
+    public static final String SWORD_STATE_DESCRIPTION_URI = SWORD_TERMS_NAMESPACE + "stateDescription";
+    public static final String SWORD_STATE_URI = SWORD_TERMS_NAMESPACE + "state";
+
+    // QNames for statement elements
+    public static final QName SWORD_DEPOSITED_BY = new QName(SWORD_TERMS_NAMESPACE, "depositedBy");
+    public static final QName SWORD_DEPOSITED_ON_BEHALF_OF = new QName(SWORD_TERMS_NAMESPACE, "depositedOnBehalfOf");
+    public static final QName SWORD_DEPOSITED_ON = new QName(SWORD_TERMS_NAMESPACE, "depositedOn");
+    public static final QName SWORD_ORIGINAL_DEPOSIT = new QName(SWORD_TERMS_NAMESPACE, "originalDeposit");
+    public static final QName SWORD_STATE_DESCRIPTION = new QName(SWORD_TERMS_NAMESPACE, "stateDescription");
+    public static final QName SWORD_STATE = new QName(SWORD_TERMS_NAMESPACE, "state");
 
     // rel values
     public static final String REL_STATEMENT = "http://purl.org/net/sword/terms/statement";


### PR DESCRIPTION
This fixes issue #190. A dependency updated which changed the default behaviour of a constructor call. This fixes it so that it calls the constructor correctly (which it's already doing in the same file.)

#### Where should the reviewer @DANS-KNAW/easy start?

I'd recommend checking that your systems don't break with the change, though I consider this unlikely. If you prefer, we could talk about automated testing...

#### How should this be manually tested?

Test this in DSpace by submitting a package to DSpace using the sword endpoint. See the [original issue](https://github.com/DSpace/DSpace/issues/10399). I've been able to test this and verify that the changes work my institution's instance of DSpace.